### PR TITLE
Draft: Add support for partial checkpoint restore

### DIFF
--- a/t5x/train.py
+++ b/t5x/train.py
@@ -326,7 +326,12 @@ def train(
           # Restore dataset state if it is being saved.
           restore_dataset=(checkpoint_cfg.save and
                            checkpoint_cfg.save.save_dataset),
-          state_transformation_fns=state_transforms_for_restore)
+          state_transformation_fns=state_transforms_for_restore,
+          strict=(checkpoint_cfg.restore.strict
+                  if checkpoint_cfg.restore is not None else True),
+          fallback_to_scratch=(checkpoint_cfg.restore.fallback_to_scratch
+                               if checkpoint_cfg.restore is not None else False))
+
   ]
   # 2. From a checkpoint specified by `checkpoint_cfg.restore.path`, if set.
   if checkpoint_cfg.restore:


### PR DESCRIPTION
This change allows partial checkpoint restores to be configurable, which is often needed when fine-tuning from a pretrained checkpoint. You can add the following code to your gin config to restore only a subset of the model variables from the given checkpoint: 
```
utils.RestoreCheckpointConfig:
  fallback_to_scratch = True
  strict = False
  state_transformation_fns = [@state_transform]
```
where `state_transform` determines which parameters to restore. For example, to restore only model weights and reset optimizer states, we can use the following transformation function: 
```
def just_states_transform(checkpoint, opt_state):
    return state_utils.apply_assignment_map(checkpoint, opt_state,
        assignment_map=[(r'state.*', None)])
```
Mapping all variables beginning with `state.` (i.e. the optimizer states) to `None` causes them to be ignored during checkpoint restore. All variables beginning with `target.` (i.e. the model weights) will be restored.